### PR TITLE
feat(uport): Switch to Ropsten

### DIFF
--- a/src/uport.js
+++ b/src/uport.js
@@ -9,8 +9,8 @@ import QRDisplay from '../utils/qrdisplay'
 
 const CHASQUI_URL = 'https://chasqui.uport.me/api/v1/topic/'
 // these are consensysnet constants, replace with mainnet before release!
-const INFURA_CONSENSYSNET = 'https://consensysnet.infura.io:8545'
-const UPORT_REGISTRY_ADDRESS = '0xa9be82e93628abaac5ab557a9b3b02f711c0151c'
+const INFURA_ROPSTEN = 'https://ropsten.infura.io'
+const UPORT_REGISTRY_ADDRESS = '0xb9C1598e24650437a3055F7f66AC1820c419a679'
 
 /**
  * This class is the main entry point for interaction with uport.
@@ -55,7 +55,7 @@ class Uport {
 
     // data source
     var rpcSubprovider = new RpcSubprovider({
-      rpcUrl: rpcUrl || INFURA_CONSENSYSNET
+      rpcUrl: rpcUrl || INFURA_ROPSTEN
     })
     this.web3Provider.addProvider(rpcSubprovider)
 

--- a/tutorial/friendwallet_step1.js
+++ b/tutorial/friendwallet_step1.js
@@ -2,7 +2,7 @@
 
 // Setup
 
-const rpcUrl = 'https://consensysnet.infura.io:8545'
+const rpcUrl = 'https://ropsten.infura.io'
 const Uport = window.uportlib.Uport
 const web3 = new Web3()
 const appName = 'FriendWallet'

--- a/tutorial/friendwallet_step2.js
+++ b/tutorial/friendwallet_step2.js
@@ -2,7 +2,7 @@
 
 // Setup
 
-const rpcUrl = 'https://consensysnet.infura.io:8545'
+const rpcUrl = 'https://ropsten.infura.io'
 const Uport = window.uportlib.Uport
 const web3 = new Web3()
 const appName = 'FriendWallet'

--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -40,7 +40,7 @@ We will create a file `friendwallet_step1.js` that will contain the JavaScript i
 To begin with we add the necessary code to set up the `web3` object with the uPort provider:
 
 ```
-const rpcUrl = 'https://consensysnet.infura.io:8545'
+const rpcUrl = 'https://ropsten.infura.io'
 const Uport = window.uportlib.Uport
 const web3 = new Web3()
 const appName = 'FriendWallet'


### PR DESCRIPTION
Update `uport.js` and tutorials to use the Ropsten network instead of ConsensysNet.