### PR TITLE
fix(uport): Make isOnMobile work on iPad

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
   "dependencies": {
     "async": "^2.0.1",
     "ipfs-mini": "^1.0.1",
-    "is-mobile": "^0.2.2",
     "json-loader": "^0.5.4",
     "jsontokens": "^0.6.5",
+    "mobile-detect": "^1.3.5",
     "nets": "^3.2.0",
     "qr-image": "^3.1.0",
     "qs": "^6.2.1",

--- a/src/uport.js
+++ b/src/uport.js
@@ -1,7 +1,7 @@
 import UportSubprovider from './uportsubprovider'
 import MsgServer from './msgServer'
 import { Registry } from 'uport-persona'
-import isMobile from 'is-mobile'
+import MobileDetect from 'mobile-detect'
 import Web3 from 'web3'
 import ProviderEngine from 'web3-provider-engine'
 import RpcSubprovider from 'web3-provider-engine/subproviders/rpc'
@@ -43,7 +43,8 @@ class Uport {
       registrySettings.ipfs = opts.ipfsProvider
     }
     this.rpcUrl = opts.rpcUrl || (INFURA_ROPSTEN + '/' + this.infuraApiKey)
-    this.isOnMobile = isMobile(navigator.userAgent)
+    const md = new MobileDetect(navigator.userAgent)
+    this.isOnMobile = (md.mobile() !== null)
     const chasquiUrl = opts.chasquiUrl || CHASQUI_URL
     this.msgServer = new MsgServer(chasquiUrl, this.isOnMobile)
     this.subprovider = this.createUportSubprovider()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3472,10 +3472,6 @@ is-ipfs@^0.2.1:
     bs58 "^3.0.0"
     multihashes "^0.2.0"
 
-is-mobile@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/is-mobile/-/is-mobile-0.2.2.tgz#0e2e006d99ed2c2155b761df80f2a3619ae2ad9f"
-
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz#936edda3ca3c211fd98f3b2d3e08da43f7b2915b"
@@ -4337,6 +4333,10 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mobile-detect@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/mobile-detect/-/mobile-detect-1.3.5.tgz#96d6511284f35d352eaf71baef459c61aebd30b2"
 
 mocha@^3.0.2:
   version "3.2.0"


### PR DESCRIPTION
Change from using the `is-mobile` package that doesn't recognize iPad, to using `mobile-detect` that does recognize the iPad.